### PR TITLE
Fixes banner breaking viewport

### DIFF
--- a/storefront/settings/routes/home/HomePage@vtex.storefront-theme/banner.json
+++ b/storefront/settings/routes/home/HomePage@vtex.storefront-theme/banner.json
@@ -4,7 +4,8 @@
     "slider": {
       "dots": false,
       "infinite": true,
-      "speed": "300"
+      "speed": "300",
+      "arrows": false
     },
     "images": [
       {


### PR DESCRIPTION
Added to Banner settings `arrows: false`, the right arrow was breaking the viewport.
